### PR TITLE
Add config to set the apache binary_path

### DIFF
--- a/apache-config.yml.sample
+++ b/apache-config.yml.sample
@@ -29,6 +29,10 @@ integrations:
     INVENTORY: "true"
     # status_url is used to identify the monitored entity to which the inventory will be attached.
     STATUS_URL: http://127.0.0.1/server-status?auto
+
+    # binary_path is used to specify the path of the apache binary file (i.e. "C:\Apache\bin\httpd.exe").
+    # By default the integration automatically discovers the binary on "/usr/sbin/httpd" or "/usr/sbin/apache2ctl". Use this setting for any other location.
+    # BINARY_PATH: ""
     
     # Alternative Certificate Authority bundle directory and file
     # CA_BUNDLE_DIR: ""

--- a/src/apache.go
+++ b/src/apache.go
@@ -22,6 +22,7 @@ import (
 type argumentList struct {
 	sdkArgs.DefaultArgumentList
 	StatusURL        string `default:"http://127.0.0.1/server-status?auto" help:"Apache status-server URL."`
+	BinaryPath       string `default:"" help:"Set location of the Apache binary"`
 	CABundleFile     string `default:"" help:"Alternative Certificate Authority bundle file"`
 	CABundleDir      string `default:"" help:"Alternative Certificate Authority bundle directory"`
 	RemoteMonitoring bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true."`
@@ -75,7 +76,7 @@ func main() {
 
 	if args.HasInventory() {
 		log.Debug("Fetching data for '%s' integration", integrationName+"-inventory")
-		fatalIfErr(setInventory(e.Inventory))
+		fatalIfErr(setInventory(e.Inventory, args.BinaryPath))
 	}
 
 	if args.HasMetrics() {

--- a/src/inventory.go
+++ b/src/inventory.go
@@ -11,16 +11,24 @@ import (
 	"strings"
 )
 
-func getBinPath() (string, error) {
-	// Check first for RedHat
-	binPath := "/usr/sbin/httpd"
-	_, err := os.Stat(binPath)
-	if err != nil {
-		// If it isn't a RedHat, try with Debian
-		binPath = "/usr/sbin/apache2ctl"
-		_, derr := os.Stat(binPath)
-		if derr != nil {
-			return "", fmt.Errorf("it isn't possible to locate Apache executable")
+func getBinPath(binPath string) (string, error) {
+	// Check if path sent through config is valid
+	if binPath != "" {
+		_, err := os.Stat(binPath)
+		if err != nil {
+			return "", fmt.Errorf("it isn't possible to locate Apache executable on the provided Binary_Path config setting")
+		}
+	} else {
+		// Check first for RedHat
+		binPath := "/usr/sbin/httpd"
+		_, err := os.Stat(binPath)
+		if err != nil {
+			// If it isn't a RedHat, try with Debian
+			binPath = "/usr/sbin/apache2ctl"
+			_, derr := os.Stat(binPath)
+			if derr != nil {
+				return "", fmt.Errorf("it isn't possible to locate Apache executable. Try using Binary-Path setting")
+			}
 		}
 	}
 	return binPath, nil
@@ -28,8 +36,8 @@ func getBinPath() (string, error) {
 
 // setInventory executes system command in order to retrieve required inventory data and calls functions which parse the result.
 // It returns a map of inventory data
-func setInventory(inventory *inventory.Inventory) error {
-	commandPath, err := getBinPath()
+func setInventory(inventory *inventory.Inventory, configBinaryPath string) error {
+	commandPath, err := getBinPath(configBinaryPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding a flag `binary_path` to set the path of the Apache binary in case it is not on one of the default locations

This addresses https://github.com/newrelic/nri-apache/issues/63