### PR TITLE
Pipeline refactor

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -120,7 +120,8 @@ jobs:
       - name: Download zip from GH Release assets and extract .exe
         shell: pwsh
         run: |
-          build\windows\download_zip_extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\download_zip.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG" "$env:REPO_FULL_NAME"
+          build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
       - name: Create MSI
         shell: pwsh
         run: |

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -6,12 +6,13 @@ on:
       - main
       - master
   pull_request:
+  workflow_dispatch:
 
 env:
   INTEGRATION: "apache"
   ORIGINAL_REPO_NAME: "newrelic/nri-apache"
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  TAG: "v1.2.3" # needed for fake-prereleases
+  TAG: "v0.0.0" # needed for fake-prereleases
 
 jobs:
   static-analysis:
@@ -57,7 +58,7 @@ jobs:
           go-version-file: "src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
       - name: Running unit tests
         shell: pwsh
-        run: .\build\windows\unit_tests.ps1
+        run: build\windows\unit_tests.ps1
 
   # can't run this step inside of container because of tests specific
   test-integration-nix:
@@ -90,7 +91,12 @@ jobs:
       GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
     steps:
       - uses: actions/checkout@v3
-      - run: git tag "$TAG"
+      - run: |
+          git tag "$TAG"
+          if [ -z "$GPG_PASSPHRASE" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          fi
+
       - name: Build all platforms:arch
         run: make ci/fake-prerelease
       - name: Upload artifacts for next job
@@ -130,7 +136,13 @@ jobs:
 
       - name: Get PFX certificate from GH secrets
         shell: bash
-        run: printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+        run: |
+          if [ -z "$PFX_CERTIFICATE_BASE64" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          else
+            printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+          fi
+
       - name: Extract .exe
         shell: pwsh
         run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
 
 env:
-  TAG: "v0.0.0" # needed for goreleaser windows builds
-  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+  INTEGRATION: "apache"
   ORIGINAL_REPO_NAME: "newrelic/nri-apache"
-  DOCKER_LOGIN_AVAILABLE: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+  TAG: "v0.0.0" # needed for goreleaser windows builds
 
 jobs:
   static-analysis:
@@ -91,13 +91,14 @@ jobs:
       TAG: v1.2.3
     steps:
       - uses: actions/checkout@v3
+      - run: git tag "$TAG"
       - name: Build all platforms:arch
         run: make ci/fake-prerelease
       - name: Upload artifacts for next job
         uses: actions/upload-artifact@v3
         with:
           name: windows-packages
-          path: dist/nri-win_*
+          path: dist/nri-*.zip
 
   test-build-windows:
     name: Create MSI
@@ -120,15 +121,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+      - shell: bash
+        run: git tag "$TAG"
 
-      - name: Create dist folder
-        run: mkdir dist
       - name: Download artifact from previous job
         if: needs.docker-build.result != 'skipped'
         uses: actions/download-artifact@v3
         with:
           name: windows-packages
           path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/dist/
+
+      - shell: cmd
+        run: |
+          dir D:\a\nri-apache\nri-apache\src\github.com\newrelic\nri-apache\
+          dir D:\a\nri-apache\nri-apache\src\github.com\newrelic\nri-apache\dist
 
       - name: Get PFX certificate from GH secrets
         shell: bash

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -57,8 +57,7 @@ jobs:
           go-version-file: "src/github.com/${{ env.ORIGINAL_REPO_NAME }}/go.mod"
       - name: Running unit tests
         shell: pwsh
-        run: |
-          .\build\windows\unit_tests.ps1
+        run: .\build\windows\unit_tests.ps1
 
   # can't run this step inside of container because of tests specific
   test-integration-nix:
@@ -82,10 +81,61 @@ jobs:
           GOPATH: ${{ github.workspace }}
         run: make integration-test
 
-  test-build:
-    name: Test binary compilation for all platforms:arch
+  test-build-nix:
+    name: Test binary compilation and packaging for linux
     runs-on: ubuntu-latest
+    env:
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+      TAG: v1.2.3
     steps:
       - uses: actions/checkout@v3
       - name: Build all platforms:arch
-        run: make ci/build
+        run: make ci/fake-prerelease
+      - name: Upload artifacts for next job
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-packages
+          path: dist/nri-win_*
+
+  test-build-windows:
+    name: Create MSI
+    runs-on: windows-latest
+    needs: [test-build-nix]
+    env:
+      GOPATH: ${{ github.workspace }}
+      PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded
+      PFX_CERTIFICATE_DESCRIPTION: 'New Relic'
+      PFX_PASSPHRASE:  ${{ secrets.OHAI_PFX_PASSPHRASE }}
+      TAG: v1.2.3
+    defaults:
+      run:
+        working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+    strategy:
+      matrix:
+        goarch: [amd64,386]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
+
+      - name: Create dist folder
+        run: mkdir dist
+      - name: Download artifact from previous job
+        if: needs.docker-build.result != 'skipped'
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-packages
+          path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/dist/
+
+      - name: Get PFX certificate from GH secrets
+        shell: bash
+        run: printf "%s" "$PFX_CERTIFICATE_BASE64" | base64 -d - > wincert.pfx
+      - name: Extract .exe
+        shell: pwsh
+        run: build\windows\extract_exe.ps1 "$env:INTEGRATION" ${{ matrix.goarch }} "$env:TAG"
+      - name: Create MSI
+        shell: pwsh
+        run: build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -11,7 +11,7 @@ env:
   INTEGRATION: "apache"
   ORIGINAL_REPO_NAME: "newrelic/nri-apache"
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  TAG: "v0.0.0" # needed for goreleaser windows builds
+  TAG: "v1.2.3" # needed for fake-prereleases
 
 jobs:
   static-analysis:
@@ -88,7 +88,6 @@ jobs:
       GPG_MAIL: 'infrastructure-eng@newrelic.com'
       GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
       GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-      TAG: v1.2.3
     steps:
       - uses: actions/checkout@v3
       - run: git tag "$TAG"
@@ -109,7 +108,6 @@ jobs:
       PFX_CERTIFICATE_BASE64: ${{ secrets.OHAI_PFX_CERTIFICATE_BASE64 }} # base64 encoded
       PFX_CERTIFICATE_DESCRIPTION: 'New Relic'
       PFX_PASSPHRASE:  ${{ secrets.OHAI_PFX_PASSPHRASE }}
-      TAG: v1.2.3
     defaults:
       run:
         working-directory: src/github.com/${{ env.ORIGINAL_REPO_NAME }}
@@ -125,16 +123,10 @@ jobs:
         run: git tag "$TAG"
 
       - name: Download artifact from previous job
-        if: needs.docker-build.result != 'skipped'
         uses: actions/download-artifact@v3
         with:
           name: windows-packages
           path: src/github.com/${{ env.ORIGINAL_REPO_NAME }}/dist/
-
-      - shell: cmd
-        run: |
-          dir D:\a\nri-apache\nri-apache\src\github.com\newrelic\nri-apache\
-          dir D:\a\nri-apache\nri-apache\src\github.com\newrelic\nri-apache\dist
 
       - name: Get PFX certificate from GH secrets
         shell: bash

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -79,7 +79,7 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
     files:
       - apache-config.yml.sample
-      - apache-log-win.yml.example
+      - apache-log.yml.example
       - src: 'legacy/apache-definition.yml'
         dst: .
         strip_parent: true
@@ -91,6 +91,7 @@ archives:
     name_template: "{{ .ProjectName }}-{{ .Arch }}.{{ .Version }}_dirty"
     files:
       - apache-config.yml.sample
+      - apache-log-win.yml.example
       - src: 'legacy/apache-win-definition.yml'
         dst: .
         strip_parent: true

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -62,3 +62,26 @@ else
 	@echo "===> $(INTEGRATION) ===  [ci/prerelease] TAG env variable expected to be set"
 	exit 1
 endif
+
+.PHONY : ci/fake-prerelease
+ci/fake-prerelease: ci/deps
+ifdef TAG
+	@docker run --platform linux/amd64 --rm -t \
+			--name "nri-$(INTEGRATION)-prerelease" \
+			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-e INTEGRATION \
+			-e PRERELEASE=true \
+			-e NO_PUBLISH=true \
+			-e NO_SIGN=true \
+			-e GITHUB_TOKEN \
+			-e REPO_FULL_NAME \
+			-e TAG \
+			-e GPG_MAIL \
+			-e GPG_PASSPHRASE \
+			-e GPG_PRIVATE_KEY_BASE64 \
+			$(BUILDER_TAG) make release
+else
+	@echo "===> $(INTEGRATION) ===  [ci/fake-prerelease] TAG env variable expected to be set"
+	exit 1
+endif

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -66,14 +66,13 @@ endif
 .PHONY : ci/fake-prerelease
 ci/fake-prerelease: ci/deps
 ifdef TAG
-	@docker run --platform linux/amd64 --rm -t \
+	@docker run --rm -t \
 			--name "nri-$(INTEGRATION)-prerelease" \
 			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-e INTEGRATION \
 			-e PRERELEASE=true \
 			-e NO_PUBLISH=true \
-			-e NO_SIGN=true \
 			-e GITHUB_TOKEN \
 			-e REPO_FULL_NAME \
 			-e TAG \

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -73,6 +73,7 @@ ifdef TAG
 			-e INTEGRATION \
 			-e PRERELEASE=true \
 			-e NO_PUBLISH=true \
+			-e NO_SIGN \
 			-e GITHUB_TOKEN \
 			-e REPO_FULL_NAME \
 			-e TAG \

--- a/build/package/windows/nri-386-installer/Product.wxs
+++ b/build/package/windows/nri-386-installer/Product.wxs
@@ -24,7 +24,7 @@
 
         <Feature Id="ProductFeature" Title="New Relic Infrastructure Integration, nri-$(var.IntegrationName)" Level="1">
             <ComponentRef Id="CMP_V1_PLUGIN_CONFIGS"/>
-            <ComponentRed Id="CMP_V1_PLUGIN_LOG_CONFIGS"/>
+            <ComponentRef Id="CMP_V1_PLUGIN_LOG_CONFIGS"/>
             <ComponentRef Id="CMP_V1_CUSTOM_PLUGINS"/>
             <ComponentRef Id="CMP_V1_CUSTOM_PLUGINS_BIN"/>
             <ComponentGroupRef Id="CustomPluginsBinComponent"/>
@@ -103,7 +103,7 @@
             </Component>
         </ComponentGroup>
         <ComponentGroup Id="PluginLogConfigsComponent" Directory="PluginLogConfigsFolder">
-            <Component Id="CMP_NRI_$(var.IntegrationName)_LOG_CONFIG_YML" Guid="888b104cc-7b5a-4a5d-bf5c-b0d9f56cd6a0" Win64="no">
+            <Component Id="CMP_NRI_$(var.IntegrationName)_LOG_CONFIG_YML" Guid="9bf8ffe3-af6b-4f18-9fd2-aabaea54b66d" Win64="no">
                 <File Id="FILE_NRI_$(var.IntegrationName)_LOG_CONFIG_YML"
                       Name="$(var.IntegrationName)-log-win.yml.example"
                       Source="$(var.BinariesPath)New Relic\newrelic-infra\logging.d\$(var.IntegrationName)-log-win.yml.example"

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-386</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -8,7 +8,7 @@
         <SchemaVersion>2.0</SchemaVersion>
         <OutputName>nri-$(IntegrationName)-amd64</OutputName>
         <OutputType>Package</OutputType>
-        <SignToolPath>C:\Program Files (x86)\Windows Kits\10\bin\x64\</SignToolPath>
+        <SignToolPath>C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\</SignToolPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>
         <Name>newrelic-nri-$(IntegrationName)-installer</Name>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/release.mk
+++ b/build/release.mk
@@ -42,14 +42,21 @@ release/fix-archive:
 
 .PHONY : release/sign/nix
 release/sign/nix:
+ifneq ($(NO_SIGN), true)
 	@echo "===> $(INTEGRATION) === [release/sign] signing packages"
 	@bash $(CURDIR)/build/nix/sign.sh
-
+else
+	@echo "===> $(INTEGRATION) === [release/sign] signing packages is disabled by environment variable"
+endif
 
 .PHONY : release/publish
 release/publish:
+ifneq ($(NO_PUBLISH), true)
 	@echo "===> $(INTEGRATION) === [release/publish] publishing artifacts"
 	@bash $(CURDIR)/build/upload_artifacts_gh.sh
+else
+	@echo "===> $(INTEGRATION) === [release/publish] publish is disabled by environment variable"
+endif
 
 .PHONY : release
 release: release/build release/fix-archive release/sign/nix release/publish release/clean

--- a/build/windows/download_zip.ps1
+++ b/build/windows/download_zip.ps1
@@ -8,12 +8,9 @@ write-host "===> Creating dist folder"
 New-Item -ItemType directory -Path .\dist
 
 $VERSION=${TAG}.substring(1)
-$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
 $zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
 
 $zip_url="https://github.com/${REPO_FULL_NAME}/releases/download/${TAG}/${zip_name}"
 write-host "===> Downloading & extracting .exe from ${zip_url}"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest "${zip_url}" -OutFile ".\dist\${zip_name}"
-write-host "===> Expanding"
-expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"

--- a/build/windows/download_zip.ps1
+++ b/build/windows/download_zip.ps1
@@ -5,7 +5,7 @@ param (
     [string]$REPO_FULL_NAME="none"
 )
 write-host "===> Creating dist folder"
-New-Item -ItemType directory -Path .\dist
+New-Item -ItemType directory -Path .\dist -Force
 
 $VERSION=${TAG}.substring(1)
 $zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"

--- a/build/windows/extract_exe.ps1
+++ b/build/windows/extract_exe.ps1
@@ -1,10 +1,10 @@
 param (
     [string]$INTEGRATION="none",
     [string]$ARCH="amd64",
-    [string]$TAG="v0.0.0",
+    [string]$TAG="v0.0.0"
 )
 write-host "===> Creating dist folder"
-New-Item -ItemType directory -Path .\dist
+New-Item -ItemType directory -Path .\dist -Force
 
 $VERSION=${TAG}.substring(1)
 $exe_folder="nri-${INTEGRATION}_windows_${ARCH}"

--- a/build/windows/extract_exe.ps1
+++ b/build/windows/extract_exe.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$INTEGRATION="none",
+    [string]$ARCH="amd64",
+    [string]$TAG="v0.0.0",
+)
+write-host "===> Creating dist folder"
+New-Item -ItemType directory -Path .\dist
+
+$VERSION=${TAG}.substring(1)
+$exe_folder="nri-${INTEGRATION}_windows_${ARCH}"
+$zip_name="nri-${INTEGRATION}-${ARCH}.${VERSION}.zip"
+
+write-host "===> Expanding"
+expand-archive -path "dist\${zip_name}" -destinationpath "dist\${exe_folder}\"

--- a/build/windows/package_msi.ps1
+++ b/build/windows/package_msi.ps1
@@ -30,11 +30,16 @@ if ($wrong.Length  -ne 0) {
     exit -1
 }
 
-echo "===> Import .pfx certificate from GH Secrets"
-Import-PfxCertificate -FilePath wincert.pfx -Password (ConvertTo-SecureString -String $pfx_passphrase -AsPlainText -Force) -CertStoreLocation Cert:\CurrentUser\My
+$noSign = $env:NO_SIGN ?? "false"
+if ($noSign -ieq "true") {
+    echo "===> Import .pfx certificate is disabled by environment variable"
+} else {
+    echo "===> Import .pfx certificate from GH Secrets"
+    Import-PfxCertificate -FilePath wincert.pfx -Password (ConvertTo-SecureString -String $pfx_passphrase -AsPlainText -Force) -CertStoreLocation Cert:\CurrentUser\My
 
-echo "===> Show certificate installed"
-Get-ChildItem -Path cert:\CurrentUser\My\
+    echo "===> Show certificate installed"
+    Get-ChildItem -Path cert:\CurrentUser\My\
+}
 
 echo "===> Checking MSBuild.exe..."
 $msBuild = (Get-ItemProperty hklm:\software\Microsoft\MSBuild\ToolsVersions\4.0).MSBuildToolsPath
@@ -47,7 +52,7 @@ echo $msBuild
 echo "===> Building Installer"
 Push-Location -Path "build\package\windows\nri-$arch-installer"
 
-. $msBuild/MSBuild.exe nri-installer.wixproj /p:IntegrationVersion=${version} /p:IntegrationName=$integration /p:Year=$buildYear /p:pfx_certificate_description=$pfx_certificate_description
+. $msBuild/MSBuild.exe nri-installer.wixproj /p:IntegrationVersion=${version} /p:IntegrationName=$integration /p:Year=$buildYear /p:NoSign=$noSign /p:pfx_certificate_description=$pfx_certificate_description
 
 if (-not $?)
 {


### PR DESCRIPTION
We are not testing packaging at PR time. This PR add `fake-prerelease` that does exactly the same as prerelease without uploading the artifacts to GitHub.